### PR TITLE
Add reusable Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -1,0 +1,32 @@
+name: Claude Review Reusable
+
+on:
+  workflow_call:
+
+jobs:
+  claude-review:
+    name: Claude Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for correctness, regressions, security,
+            and missing tests. Post findings as GitHub PR comments.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary\nAdd an org-shared reusable workflow for Claude PR review.\n\n## Why\nThis centralizes review logic so all repos can call one workflow and inherit updates.\n\n## Includes\n-  with OAuth-token auth\n- Consistent prompt and review tooling for PR comments\n