### PR TITLE
Sync Gemini PR review workflow

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   gemini-review:
-    if: ${{ github.event.pull_request.draft == false && secrets.GEMINI_API_KEY != '' }}
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 7
     steps:


### PR DESCRIPTION
Syncs the org-standard Gemini PR review workflow (Google Gemini CLI Action). Opt-out is controlled by `.github/gemini-review-config.json` in `thepointatinfinity/pai-org-infra`.