### PR TITLE
[codex] Gate Claude review on API key auth

### DIFF
--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -17,10 +17,27 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Select Claude auth mode
+        id: claude-auth
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "mode=api-key" >> "$GITHUB_OUTPUT"
+          elif [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "mode=skip" >> "$GITHUB_OUTPUT"
+            echo "::notice::Claude PR Review skipped: this organization has Claude Code subscription OAuth disabled. Configure the ANTHROPIC_API_KEY org/repo secret to re-enable automated review."
+          else
+            echo "mode=skip" >> "$GITHUB_OUTPUT"
+            echo "::notice::Claude PR Review skipped: neither ANTHROPIC_API_KEY nor CLAUDE_CODE_OAUTH_TOKEN is configured."
+          fi
+
       - name: Run Claude Code Review
+        if: steps.claude-auth.outputs.mode == 'api-key'
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Prefer ANTHROPIC_API_KEY for the reusable Claude PR review workflow
- Skip with an explicit notice when only the currently-disabled Claude Code OAuth token is configured
- Avoid making downstream PRs fail because the organization has disabled Claude subscription access for Claude Code

## Context
Recent runtime-autotune-control-plane PRs #12 and #13 failed only at Claude Review with: `Your organization has disabled Claude subscription access for Claude Code`. The org currently has `CLAUDE_CODE_OAUTH_TOKEN` configured but no `ANTHROPIC_API_KEY` secret.